### PR TITLE
#16 allow case override at individual TokenType level

### DIFF
--- a/dist/BrightScriptFormatter.d.ts
+++ b/dist/BrightScriptFormatter.d.ts
@@ -62,4 +62,10 @@ export interface FormattingOptions {
      * If false, trailing white space is left intact
      */
     removeTrailingWhiteSpace?: boolean;
+    /**
+     * Provides a way to override keyword case at the individual TokenType level
+     */
+    keywordCaseOverride?: {
+        [id: string]: FormattingOptions['keywordCase'];
+    };
 }

--- a/dist/BrightScriptFormatter.js
+++ b/dist/BrightScriptFormatter.js
@@ -69,6 +69,7 @@ var BrightScriptFormatter = /** @class */ (function () {
                     token.value = parts[0] + parts[1];
                 }
                 else {
+                    // if(options.compositeKeywords === 'split'){
                     token.value = parts[0] + ' ' + parts[1];
                 }
                 var offsetDifference = token.value.length - tokenValue.length;
@@ -87,6 +88,7 @@ var BrightScriptFormatter = /** @class */ (function () {
             return [token.value.substring(0, 5), token.value.substring(5).trim()];
         }
         else {
+            // if (lowerValue.indexOf('exit') === 0 || lowerValue.indexOf('else') === 0) {
             return [token.value.substring(0, 4), token.value.substring(4).trim()];
         }
     };
@@ -95,7 +97,11 @@ var BrightScriptFormatter = /** @class */ (function () {
             var token = tokens_4[_i];
             //if this token is a keyword
             if (brightscript_parser_1.KeywordTokenTypes.indexOf(token.tokenType) > -1) {
-                switch (options.keywordCase) {
+                var keywordCase = options.keywordCase;
+                if (options.keywordCaseOverride && options.keywordCaseOverride[token.tokenType] !== undefined) {
+                    keywordCase = options.keywordCaseOverride[token.tokenType];
+                }
+                switch (keywordCase) {
                     case 'lower':
                         token.value = token.value.toLowerCase();
                         break;
@@ -105,7 +111,9 @@ var BrightScriptFormatter = /** @class */ (function () {
                     case 'title':
                         var lowerValue = token.value.toLowerCase();
                         if (brightscript_parser_1.CompositeKeywordTokenTypes.indexOf(token.tokenType) === -1) {
-                            token.value = token.value.substring(0, 1).toUpperCase() + token.value.substring(1).toLowerCase();
+                            token.value =
+                                token.value.substring(0, 1).toUpperCase() +
+                                    token.value.substring(1).toLowerCase();
                         }
                         else {
                             var spaceCharCount = (lowerValue.match(/\s+/) || []).length;
@@ -114,6 +122,7 @@ var BrightScriptFormatter = /** @class */ (function () {
                                 firstWordLength = 3;
                             }
                             else {
+                                //if (lowerValue.indexOf('exit') > -1 || lowerValue.indexOf('else') > -1)
                                 firstWordLength = 4;
                             }
                             token.value =
@@ -124,9 +133,13 @@ var BrightScriptFormatter = /** @class */ (function () {
                                     //add back the whitespace
                                     token.value.substring(firstWordLength, firstWordLength + spaceCharCount) +
                                     //first character of second word
-                                    token.value.substring(firstWordLength + spaceCharCount, firstWordLength + spaceCharCount + 1).toUpperCase() +
+                                    token.value
+                                        .substring(firstWordLength + spaceCharCount, firstWordLength + spaceCharCount + 1)
+                                        .toUpperCase() +
                                     //rest of second word
-                                    token.value.substring(firstWordLength + spaceCharCount + 1).toLowerCase();
+                                    token.value
+                                        .substring(firstWordLength + spaceCharCount + 1)
+                                        .toLowerCase();
                         }
                 }
             }
@@ -212,7 +225,9 @@ var BrightScriptFormatter = /** @class */ (function () {
             tabCount = tabCount < 0 ? 0 : tabCount;
             var leadingWhitespace = void 0;
             if (options.indentStyle === 'spaces') {
-                var indentSpaceCount = options.indentSpaceCount ? options.indentSpaceCount : BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT;
+                var indentSpaceCount = options.indentSpaceCount
+                    ? options.indentSpaceCount
+                    : BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT;
                 var spaceCount = thisTabCount * indentSpaceCount;
                 leadingWhitespace = Array(spaceCount + 1).join(' ');
             }
@@ -262,7 +277,8 @@ var BrightScriptFormatter = /** @class */ (function () {
                 lineTokens.splice(potentialWhitespaceTokenIndex, 1);
                 //if the final token is a comment, trim the whitespace from the righthand side
             }
-            else if (whitespaceTokenCandidate.tokenType === brightscript_parser_1.TokenType.quoteComment || whitespaceTokenCandidate.tokenType === brightscript_parser_1.TokenType.remComment) {
+            else if (whitespaceTokenCandidate.tokenType === brightscript_parser_1.TokenType.quoteComment ||
+                whitespaceTokenCandidate.tokenType === brightscript_parser_1.TokenType.remComment) {
                 whitespaceTokenCandidate.value = trimRight(whitespaceTokenCandidate.value);
             }
             //add this line to the output
@@ -294,7 +310,8 @@ var BrightScriptFormatter = /** @class */ (function () {
         for (index = startIndex; index < tokens.length; index++) {
             var token = tokens[index];
             outputTokens[outputTokens.length] = token;
-            if (token.tokenType === brightscript_parser_1.TokenType.newline || token.tokenType === brightscript_parser_1.TokenType.END_OF_FILE) {
+            if (token.tokenType === brightscript_parser_1.TokenType.newline ||
+                token.tokenType === brightscript_parser_1.TokenType.END_OF_FILE) {
                 break;
             }
         }
@@ -310,7 +327,8 @@ var BrightScriptFormatter = /** @class */ (function () {
             indentSpaceCount: BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT,
             keywordCase: 'lower',
             compositeKeywords: 'split',
-            removeTrailingWhiteSpace: true
+            removeTrailingWhiteSpace: true,
+            keywordCaseOverride: {}
         };
         if (options) {
             for (var attrname in options) {
@@ -330,10 +348,15 @@ var BrightScriptFormatter = /** @class */ (function () {
         if (elseIndex > -1) {
             return true;
         }
+        //if there's no then, then it can't be a one line statement
+        if (thenIndex == -1) {
+            return false;
+        }
         //see if there is anything after the "then". If so, assume it's a one-line if statement
         for (var i = thenIndex + 1; i < lineTokens.length; i++) {
             var token = lineTokens[i];
-            if (token.tokenType === brightscript_parser_1.TokenType.whitespace || token.tokenType === brightscript_parser_1.TokenType.newline) {
+            if (token.tokenType === brightscript_parser_1.TokenType.whitespace ||
+                token.tokenType === brightscript_parser_1.TokenType.newline) {
                 //do nothing with whitespace and newlines
             }
             else {

--- a/src/BrightScriptFormatter.spec.ts
+++ b/src/BrightScriptFormatter.spec.ts
@@ -216,6 +216,72 @@ describe('BrightScriptFormatter', () => {
 
     });
 
+    describe('keywordCaseOverride', () => {
+        it('overrides default casing and uses lower case', () => {
+            expect(formatter.format(
+                `Sub add()\n    If true Then\n        a=1\n    ElseIf true Then\n        a=1\n    EndIf\nEndSub`,
+                {
+                    keywordCase: 'upper',
+                    compositeKeywords: null,
+                    keywordCaseOverride: {
+                        sub: "lower",
+                        endSub: "lower"
+                    }
+                }
+            )).to.equal(
+                `sub add()\n    IF true THEN\n        a=1\n    ELSEIF true THEN\n        a=1\n    ENDIF\nendsub`,
+            );
+        });
+        it('overrides default casing and uses upper case', () => {
+            expect(formatter.format(
+                `Sub add()\n    IF true THEN\n        a=1\n    ELSEIF true THEN\n        a=1\n    ENDIF\nEndSub`,
+                {
+                    keywordCase: 'lower',
+                    compositeKeywords: null,
+                    keywordCaseOverride: {
+                        sub: "upper",
+                        endSub: "upper"
+                    }
+                }
+            )).to.equal(
+                `SUB add()\n    if true then\n        a=1\n    elseif true then\n        a=1\n    endif\nENDSUB`,
+            );
+        });
+
+        it('overrides default casing and uses title case', () => {
+            expect(formatter.format(
+                `sub add()\n    IF true then\n        a=1\n    ELSEIF true THEN\n        a=1\n    end if\nENDSUB`,
+                {
+                    keywordCase: 'lower',
+                    compositeKeywords: null,
+                    keywordCaseOverride: {
+                        sub: "title",
+                        endSub: "title"
+                    }
+                }
+            )).to.equal(
+                `Sub add()\n    if true then\n        a=1\n    elseif true then\n        a=1\n    end if\nEndSub`,
+            );
+        });
+
+        it('overrides default casing and leaves casing alone', () => {
+            expect(formatter.format(
+                `SuB add()\n    IF true then\n        a=1\n    ELSEIF true THEN\n        a=1\n    endif\nEnDSuB`,
+                {
+                    keywordCase: 'lower',
+                    compositeKeywords: null,
+                    keywordCaseOverride: {
+                        sub: null,
+                        endSub: null
+                    }
+                }
+            )).to.equal(
+                `SuB add()\n    if true then\n        a=1\n    elseif true then\n        a=1\n    endif\nEnDSuB`,
+            );
+        });
+
+    });
+
     describe('composite keywords', () => {
         it('joins together when specified', () => {
             expect(formatter.format(

--- a/src/BrightScriptFormatter.ts
+++ b/src/BrightScriptFormatter.ts
@@ -107,7 +107,11 @@ export class BrightScriptFormatter {
         for (let token of tokens) {
             //if this token is a keyword
             if (KeywordTokenTypes.indexOf(token.tokenType) > -1) {
-                switch (options.keywordCase) {
+                let keywordCase = options.keywordCase;
+                if (options.keywordCaseOverride && options.keywordCaseOverride[token.tokenType] !== undefined) {
+                    keywordCase = options.keywordCaseOverride[token.tokenType];
+                }
+                switch (keywordCase) {
                     case 'lower':
                         token.value = token.value.toLowerCase();
                         break;
@@ -373,7 +377,8 @@ export class BrightScriptFormatter {
             indentSpaceCount: BrightScriptFormatter.DEFAULT_INDENT_SPACE_COUNT,
             keywordCase: 'lower',
             compositeKeywords: 'split',
-            removeTrailingWhiteSpace: true
+            removeTrailingWhiteSpace: true,
+            keywordCaseOverride: {}
         };
         if (options) {
             for (let attrname in options) {
@@ -445,4 +450,8 @@ export interface FormattingOptions {
      * If false, trailing white space is left intact
      */
     removeTrailingWhiteSpace?: boolean;
+    /**
+     * Provides a way to override keyword case at the individual TokenType level
+     */
+    keywordCaseOverride?: { [id: string]: FormattingOptions['keywordCase'] };
 }


### PR DESCRIPTION
This is the implementation for https://github.com/TwitchBronBron/brightscript-formatter/issues/16. In my config I have:
```
"brightscript.format.keywordCaseOverride": {
        "string": "title",
        "float": "title",
        "double": "title",
        "object": "title",
        "boolean": "title",
        "dynamic": "title",
        "integer": "title"
},
```
and all seems to be working well. Let me know if you see any problems or if I did something wrong. Thanks